### PR TITLE
feat(gov): add api version query

### DIFF
--- a/contracts/pylon/gov/src/constant.rs
+++ b/contracts/pylon/gov/src/constant.rs
@@ -1,1 +1,2 @@
+pub const API_VERSION: &str = "1.1.0";
 pub const POLL_EXECUTE_REPLY_ID: u64 = 1;

--- a/contracts/pylon/gov/src/contract.rs
+++ b/contracts/pylon/gov/src/contract.rs
@@ -2,12 +2,13 @@
 use cosmwasm_std::entry_point;
 
 use cosmwasm_std::{
-    from_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, Uint128,
+    from_binary, to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, Uint128,
 };
 use cw20::Cw20ReceiveMsg;
 use pylon_token::gov_msg::{Cw20HookMsg, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use pylon_token::gov_resp::APIVersionResponse;
 
-use crate::constant::POLL_EXECUTE_REPLY_ID;
+use crate::constant::{API_VERSION, POLL_EXECUTE_REPLY_ID};
 use crate::error::ContractError;
 use crate::handler::config::{query_config, update_config};
 use crate::handler::poll::{
@@ -142,6 +143,9 @@ pub fn receive_cw20(
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
     match msg {
+        QueryMsg::APIVersion {} => Ok(to_binary(&APIVersionResponse {
+            version: API_VERSION.to_string(),
+        })?),
         QueryMsg::Config {} => query_config(deps),
         QueryMsg::State {} => query_state(deps),
         QueryMsg::Staker { address } => query_staker(deps, address),

--- a/contracts/pylon/gov/src/testing/mod.rs
+++ b/contracts/pylon/gov/src/testing/mod.rs
@@ -10,6 +10,7 @@ mod test_poll_execute;
 mod test_poll_fail;
 mod test_poll_snapshot;
 mod test_poll_vote;
+mod test_query;
 mod test_query_poll;
 mod test_staking_deposit;
 mod test_staking_withdraw;

--- a/contracts/pylon/gov/src/testing/test_query.rs
+++ b/contracts/pylon/gov/src/testing/test_query.rs
@@ -1,0 +1,20 @@
+use cosmwasm_std::from_binary;
+use cosmwasm_std::testing::mock_env;
+use pylon_token::gov_msg::QueryMsg;
+use pylon_token::gov_resp::APIVersionResponse;
+
+use crate::constant::API_VERSION;
+use crate::contract;
+use crate::testing::mock_querier::mock_dependencies;
+use crate::testing::utils::mock_instantiate;
+
+#[test]
+fn query_api_version() {
+    let mut deps = mock_dependencies(&[]);
+    mock_instantiate(deps.as_mut());
+
+    let msg = QueryMsg::APIVersion {};
+    let raw_resp = contract::query(deps.as_ref(), mock_env(), msg).unwrap();
+    let resp: APIVersionResponse = from_binary(&raw_resp).unwrap();
+    assert_eq!(resp.version, API_VERSION.to_string());
+}

--- a/packages/pylon_token/src/gov_msg.rs
+++ b/packages/pylon_token/src/gov_msg.rs
@@ -91,6 +91,7 @@ pub struct MigrateMsg {}
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
+    APIVersion {},
     Config {},
     State {},
     Staker {

--- a/packages/pylon_token/src/gov_resp.rs
+++ b/packages/pylon_token/src/gov_resp.rs
@@ -5,6 +5,11 @@ use serde::{Deserialize, Serialize};
 use crate::gov_msg::{PollExecuteMsg, PollStatus, VoteOption, VoterInfo};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
+pub struct APIVersionResponse {
+    pub version: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
 pub struct ConfigResponse {
     pub owner: String,
     pub pylon_token: String,


### PR DESCRIPTION
## 👀 What is Changed?

 * Adapt semantic versioning on smart contract

## 📣 API Changes

 * Add `api_version` query

## 📝 Notes

 * Devs can easily migrate to the next version of the contract seamlessly now

## ☑️ Checklist
 - [x] The code compiles successfully
 - [x] I've run `cargo clippy` to lint and check code style
 - [x] I've written the test code and runs successfully
 - [x] I've updated API docs and noticed to the co-workers for updates
